### PR TITLE
fix arguments for remove/show/hide methods

### DIFF
--- a/src/creator.js
+++ b/src/creator.js
@@ -33,19 +33,19 @@ export default function apiCreator(Component, events = [], single = false) {
         }
         singleMap[ownerInsUid] = null
       }
-      originRemove && originRemove.call(this)
+      originRemove && originRemove.apply(this, arguments)
       instance.destroy()
     }
 
     const originShow = component.show
     component.show = function () {
-      originShow && originShow.call(this)
+      originShow && originShow.apply(this, arguments)
       return this
     }
 
     const originHide = component.hide
     component.hide = function () {
-      originHide && originHide.call(this)
+      originHide && originHide.apply(this, arguments)
       return this
     }
 


### PR DESCRIPTION
修补了vue-create-api创建的组件如果有remove/show/hide方法, 调用后参数带不过去的问题