### PR TITLE
优化销毁组件的时候触发条件

### DIFF
--- a/src/instantiate.js
+++ b/src/instantiate.js
@@ -18,7 +18,9 @@ export default function instantiateComponent(Vue, Component, data, renderFn, opt
       },
       destroy() {
         this.$destroy()
-        document.body.removeChild(this.$el)
+        if (this.$el && this.$el.parentNode) {
+          document.body.removeChild(this.$el)
+        }
       }
     }
   })

--- a/src/instantiate.js
+++ b/src/instantiate.js
@@ -18,7 +18,9 @@ export default function instantiateComponent(Vue, Component, data, renderFn, opt
       },
       destroy() {
         this.$destroy()
-        if (this.$el && this.$el.parentNode) {
+        if (this.$el &&
+            this.$el.parentNode &&
+            this.$el.parentNode.nodeName.toLocaleLowerCase() === 'body') {
           document.body.removeChild(this.$el)
         }
       }

--- a/src/instantiate.js
+++ b/src/instantiate.js
@@ -18,9 +18,7 @@ export default function instantiateComponent(Vue, Component, data, renderFn, opt
       },
       destroy() {
         this.$destroy()
-        if (this.$el &&
-            this.$el.parentNode &&
-            this.$el.parentNode.nodeName.toLocaleLowerCase() === 'body') {
+        if (this.$el && this.$el.parentNode === document.body) {
           document.body.removeChild(this.$el)
         }
       }


### PR DESCRIPTION
### 背景问题
在使用一些公共的、嵌套多层的组件发现，在调用 `this.$destroy()` 时候，会出现 `dom` 已经在内部销毁掉了，`body` 下已经没有了这个 `dom` 元素；此时再调用 ` document.body.removeChild(this.$el)` 会报 `The node to be removed is not a child of this node.`
### 解决方法
在调用 ` document.body.removeChild(this.$el)` 增加一些限制条件，确保 `dom` 存在于 `body` 之下，防止报错。

####  公共组件example
```ts
// 验证码组件
export function invokeCaptcha(
  sendHandler: Function,
  submitHandler: Function,
  mobile: number,
  context: any,
  props: any = {
    value: true,
    title: '请输入验证码',
    countNormalText: '重新发送',
    brief: '',
    maxlength: 6,
    count: 60,
  }
) {
  const captchaInstance = context.$createCaptcha({
    $props: props,
    $scopedSlots: {
      default: () =>
        `验证码已发送至到 ${mobile}`,
    },
    $events: {
      // 发送
      send: () => {
        Vue.prototype.$nextTick(sendHandler)
      },
      // 提交
      submit: (captcha: number) => {
        submitHandler && submitHandler(captcha)
      },
      // 关闭
      input: () => {
        captchaInstance.$updateProps({
          value: false,
        })
      },
    },
  })

  return captchaInstance
}
```